### PR TITLE
Wilson

### DIFF
--- a/DDL.sql
+++ b/DDL.sql
@@ -1,8 +1,217 @@
 /*
 Group: 49
 Name: Ethan Spear, Kia Wilson 
-OSUOID: _____,  wilsokia
+OSUOID: speare,  wilsokia
 Course: CS340 Section 400
 Assignment: Elden Ring Project: Step 2 Draft
 */
+
+CREATE TABLE Weapon_Categories (
+    category_id varchar(255) UNIQUE NOT NULL, 
+    PRIMARY KEY (category_id)
+);
+
+
+INSERT INTO Weapon_Categories (category_id)
+VALUES 
+    ('Katana'), 
+    ('Straight Sword'), 
+    ('Dagger'), 
+    ('Curved Greatsword');
+
+
+CREATE TABLE Weapons(
+    weapon_id int AUTO_INCREMENT UNIQUE NOT NULL,
+    name varchar(255) NOT NULL,
+    damage int NOT NULL,
+    category_id varchar(255),
+    FOREIGN KEY (category_id) REFERENCES Weapon_Categories(category_id),
+    PRIMARY KEY (weapon_id)
+);
+
+INSERT INTO Weapons(
+    name,
+    damage,
+    category_id
+)
+VALUES
+(
+    'Uchigatana',
+    115,
+    (SELECT category_id FROM Weapon_Categories WHERE Weapon_Categories.category_id = 'Katana')
+),
+(
+    'Longsword',
+    110,
+    (SELECT category_id FROM Weapon_Categories WHERE Weapon_Categories.category_id = 'Straight Sword')
+),
+(
+    "Great Knife",
+    75,
+    (SELECT category_id FROM Weapon_Categories WHERE Weapon_Categories.category_id = 'Dagger')
+),
+(
+    'Bloodhound''s Fang',
+    141,
+    (SELECT category_id FROM Weapon_Categories WHERE Weapon_Categories.category_id = 'Curved Greatsword')
+);
+
+
+CREATE TABLE Regions (
+    region_id varchar(45) UNIQUE NOT NULL,
+    PRIMARY KEY (region_id) 
+);
+
+INSERT INTO Regions (region_id)
+VALUES
+    ('Limegrave'),
+    ('Caelid'),
+    ('Miquella''s Haligree'),
+    ('Weeping Peninsula');
+
+
+CREATE TABLE Locations(
+    location_id int AUTO_INCREMENT UNIQUE NOT NULL,
+    name varchar(255) NOT NULL,
+    region_id varchar(45),
+    FOREIGN KEY (region_id) REFERENCES Regions(region_id),
+    PRIMARY KEY (location_id)
+);
+
+INSERT INTO Locations (name, region_id)
+VALUES 
+(
+    'Aeonia Swamp', 
+    (SELECT region_id FROM Regions Where region_id = 'Caelid')
+),
+(
+    'Redmane Castle',
+    (SELECT region_id FROM Regions Where region_id = 'Caelid')
+),
+(   
+    'Stormhill',
+    (SELECT region_id FROM Regions Where region_id = 'Limegrave')
+),
+(
+    ' Forlorn Hound Evergaol',
+    (SELECT region_id FROM Regions Where region_id = 'Limegrave')
+),
+(
+    'Elphael, Brace of the Haligree',
+    (SELECT region_id FROM Regions Where region_id = 'Miquella''s Haligree')
+);
+
+
+CREATE TABLE Players(
+    player_id int AUTO_INCREMENT UNIQUE NOT NULL,
+    name varchar(255) NOT NULL,
+    class varchar(55) NOT NULL,
+    level int NOT NULL,
+    death_count int,
+    location_id int,
+    FOREIGN KEY (location_id) REFERENCES Locations(location_id),
+    PRIMARY KEY (player_id)
+);
+
+INSERT INTO Players(
+    name,
+    class, 
+    level, 
+    death_count,
+    location_id
+)
+VALUES
+(
+    'Player1',
+    "Samurai",
+    32,
+    NULL,
+    (SELECT location_id FROM Locations WHERE Locations.name = 'Redmane Castle')
+),
+(
+    'Player2',
+    'Bandit',
+    112,
+    NULL,
+    (SELECT location_id FROM Locations WHERE Locations.name = 'Aeonia Swamp')
+),
+(
+    'Player3',
+    'Vagabond',
+    9,
+    NULL,
+    (SELECT location_id FROM Locations WHERE Locations.name = 'Stormhill')
+);
+
+
+Create TABLE Enemies (
+    enemy_id int AUTO_INCREMENT UNIQUE NOT NULL, 
+    name varchar(45) NOT NULL,
+    health int,
+    is_boss tinyint(1),
+    weapon_id int,
+    location_id int,
+    FOREIGN KEY (weapon_id) REFERENCES Weapons(weapon_id),
+    FOREIGN KEY (location_id) REFERENCES Locations(location_id),
+    PRIMARY KEY  (enemy_id)
+);
+    
+INSERT INTO Enemies (name, health, is_boss, weapon_id, location_id)
+VALUES 
+(
+    'Bloodhound Knight Darriwil',
+    1450,
+    1,
+    (SELECT weapon_id FROM Weapons WHERE Weapons.name = 'Bloodhound''s Fang'),
+    (SELECT location_id FROM Locations WHERE Locations.name = 'Forlorn Hound Evergaol')
+),
+(
+    'Commander O''Neil',
+    9210,
+    1,
+    (SELECT weapon_id FROM Weapons WHERE Weapons.name = 'Longsword'),
+    (SELECT location_id FROM Locations WHERE Locations.name = 'Aeonia Swamp')
+),
+(
+    'Commander O''Neil',
+    9210,
+    1,
+    (SELECT weapon_id FROM Weapons WHERE Weapons.name = 'Uchigatana'),
+    (SELECT location_id FROM Locations WHERE Locations.name = 'Limegrave')
+);
+
+
+CREATE TABLE Player_Weapons(
+    weapon_id int,
+    player_id int,
+    FOREIGN KEY (weapon_id) REFERENCES Weapons(weapon_id),
+    FOREIGN KEY (player_id) REFERENCES Players(player_id),
+    PRIMARY KEY (player_id, weapon_id)
+);
+
+INSERT INTO Player_Weapons(
+    player_id,
+    weapon_id
+)
+VALUES
+(
+    (SELECT player_id FROM Players WHERE name = 'Player1'),
+    (SELECT weapon_id FROM Weapons WHERE name = 'Uchigatana')
+),
+(
+    (SELECT player_id FROM Players WHERE name = 'Player1'),
+    (SELECT weapon_id FROM Weapons WHERE name = 'Bloodhound''s Fang')
+),
+(
+    (SELECT player_id FROM Players WHERE name = 'Player2'),
+    (SELECT weapon_id FROM Weapons WHERE name = 'Great Knife')
+),
+(
+    (SELECT player_id FROM Players WHERE name = 'Player2'),
+    (SELECT weapon_id FROM Weapons WHERE name = 'Bloodhound''s Fang')
+),
+(
+    (SELECT player_id FROM Players WHERE name = 'Player3'),
+    (SELECT weapon_id FROM Weapons WHERE name = 'Longsword')
+);
 

--- a/DDL.sql
+++ b/DDL.sql
@@ -3,6 +3,6 @@ Group: 49
 Name: Ethan Spear, Kia Wilson 
 OSUOID: _____,  wilsokia
 Course: CS340 Section 400
-Assignment: Project Step 2 Draft : Elden Ring 
+Assignment: Project Step 2 Draft 
 */
 

--- a/DDL.sql
+++ b/DDL.sql
@@ -3,6 +3,6 @@ Group: 49
 Name: Ethan Spear, Kia Wilson 
 OSUOID: _____,  wilsokia
 Course: CS340 Section 400
-Assignment: Project Step 2 Draft : ELden Ring 
+Assignment: Project Step 2 Draft : Elden Ring 
 */
 


### PR DESCRIPTION
So the header part I'm not sure what happened there with the doubling of our OIDs.

Everything else:
I wrote my queries, downloaded yours and tested them all together on VS code and PHP:

Changes to your work:
- I switched to single quotes for continuity among our query's combined with how SQL likes to handle apostrophe values 
- I added the values you used as locations, as the region id's. Now there  are region id's given we are using var char as the data type. For example, Aeonia Swamp = location name, Caelid = region_id. I used the wiki to to find locations that were in the region(former locations) you provided. 

Outside of that the query's are organized based on dependency so when they are created in the database there are no errors key errors ( IE something being created before something it depends on exits).

I'm still unsure about the commits so hopefully that did not break anything. I'm also going to just upload our combined SQL file of queries onto Teams.